### PR TITLE
Fix incorporation of all additive QTNs from a user-defined QTN_list

### DIFF
--- a/R/qtn_from_user.R
+++ b/R/qtn_from_user.R
@@ -50,7 +50,7 @@ qtn_from_user <-
       epi_ef_trait_obj <- NULL
       if (!is.null(unlist(QTN_list$add)) & add) {
         add_ef_trait_obj <-
-          lapply(QTN_list$add[[1]], function(i) {
+          lapply(QTN_list$add, function(i) {
             a <- genotypes[genotypes$snp %in% i,]
             rownames(a) <- a$snp
             a <- a[i,]


### PR DESCRIPTION
Edited line 53 of file "qtn_from_user.R" to ensure of all the additive QTNs from a user-defined QTN_list are modeled in the simulated trait. 